### PR TITLE
Specify User-Agent

### DIFF
--- a/autoscaler.go
+++ b/autoscaler.go
@@ -39,6 +39,7 @@ func run(cfg Config) {
 		Password:          cfg.ApiPassword,
 		SkipSslValidation: cfg.SkipSslValidation,
 		HttpClient:        &http.Client{Timeout: 10 * time.Second},
+		UserAgent:         "SimpleAutoscaler/"+version,
 	})
 	if err != nil {
 		cfg.Logger.Fatal(errors.Wrap(err, "create cf client"))

--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-const version = "1.0"
+const version = "1.1"
 
 func main() {
 	logger := log.New(os.Stderr, "", log.Lshortfile)


### PR DESCRIPTION
Use a explicit user-agent (SimpleAutoscaler/1.0) when talking with CAPI.